### PR TITLE
アプリのカラー設定

### DIFF
--- a/lib/config/app_routes.dart
+++ b/lib/config/app_routes.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:sweets_app_sample/config/app_config.dart';
 import 'package:sweets_app_sample/model/route_data_model.dart';
 import 'package:sweets_app_sample/ui/pages/top.dart';
+import 'package:sweets_app_sample/ui/templates/app_colors_template.dart';
+import 'package:sweets_app_sample/ui/templates/template_top.dart';
 
 class AppRoutes {
   final List<RouteDataModel> _routeList = [
@@ -9,6 +11,19 @@ class AppRoutes {
       pageName: Pages.top.name,
       routeName: Pages.top.routeName,
       widgetBuilder: (BuildContext context) => const Top(),
+    ),
+    // デバッグ用
+    RouteDataModel(
+      pageName: Pages.templateTop.name,
+      routeName: Pages.templateTop.routeName,
+      isDebug: true,
+      widgetBuilder: (BuildContext context) => const TemplateTop(),
+    ),
+    RouteDataModel(
+      pageName: Pages.appColorsTemplate.name,
+      routeName: Pages.appColorsTemplate.routeName,
+      isDebug: true,
+      widgetBuilder: (BuildContext context) => const AppColorsTemplate(),
     ),
   ];
 
@@ -34,15 +49,21 @@ class AppRoutes {
 // 以下ページ一覧設定
 enum Pages {
   top,
+  templateTop,
+  appColorsTemplate,
 }
 
 extension PageNameExtension on Pages {
   static final names = {
     Pages.top: 'トップページ',
+    Pages.templateTop: 'テンプレートトップ',
+    Pages.appColorsTemplate: 'カラーテンプレート',
   };
 
   static final rootNames = {
     Pages.top: '/top',
+    Pages.templateTop: '/templateTop',
+    Pages.appColorsTemplate: '/appColorsTemplate'
   };
 
   String get routeName => rootNames[this] ?? '';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:sweets_app_sample/config/app_routes.dart';
+import 'package:sweets_app_sample/ui/atoms/app_theme.dart';
 import 'package:sweets_app_sample/ui/pages/top.dart';
 
 void main() {
@@ -15,9 +16,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return GetMaterialApp(
       title: 'sweets_app',
-      theme: ThemeData(
-        primarySwatch: Colors.blue,
-      ),
+      theme: AppTheme().style(),
       home: const Top(),
       routes: AppRoutes().routeList(),
     );

--- a/lib/ui/atoms/app_colors.dart
+++ b/lib/ui/atoms/app_colors.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+class AppColors {
+  // Theme
+  static const Color primary = Color(0xFF53D9A9);
+  static const Color secondary = Color(0xFF6ADBEB);
+  static const Color disable = Color(0xFFF3F3F3);
+
+  // Background
+  static const Color bgWhite = Color(0xFFFFFFFF);
+
+  // Stroke
+  static const Color stroke = Color(0xFFD6D6D6);
+
+  // Text Color
+  static const Color textBlack = Color(0xFF333333);
+  static const Color textGray = Color(0xFF838383);
+  static const Color textBtnWhite = Color(0xFFFFFFFF);
+  static const Color textButton = Color(0xFF53D9A9);
+}

--- a/lib/ui/atoms/app_theme.dart
+++ b/lib/ui/atoms/app_theme.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+import 'package:sweets_app_sample/ui/atoms/app_colors.dart';
+
+class AppTheme {
+  ThemeData style() {
+    return ThemeData(
+      appBarTheme: const AppBarTheme(
+        backgroundColor: AppColors.primary,
+      ),
+      brightness: Brightness.light,
+    );
+  }
+}

--- a/lib/ui/pages/top.dart
+++ b/lib/ui/pages/top.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:sweets_app_sample/config/app_config.dart';
+import 'package:sweets_app_sample/ui/atoms/app_colors.dart';
 import 'package:sweets_app_sample/viewmodel/top_view_mode.dart';
 
 class Top extends StatelessWidget {
@@ -23,6 +24,7 @@ class Top extends StatelessWidget {
           ? null
           : FloatingActionButton(
               onPressed: viewModel.toTemplate,
+              backgroundColor: AppColors.secondary,
               child: const Icon(Icons.adb),
             ),
     );

--- a/lib/ui/pages/top.dart
+++ b/lib/ui/pages/top.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 import 'package:sweets_app_sample/config/app_config.dart';
+import 'package:sweets_app_sample/viewmodel/top_view_mode.dart';
 
 class Top extends StatelessWidget {
   const Top({Key? key}) : super(key: key);
@@ -7,6 +9,8 @@ class Top extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // initialize getX Controller
+    final viewModel = Get.put<TopViewModelInterface>(TopViewModel.instance);
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('sweets_app'),
@@ -17,9 +21,9 @@ class Top extends StatelessWidget {
       // デバッグ時のみフローティングボタンを表示
       floatingActionButton: AppConfig().isRelease()
           ? null
-          : const FloatingActionButton(
-              onPressed: null,
-              child: Icon(Icons.adb),
+          : FloatingActionButton(
+              onPressed: viewModel.toTemplate,
+              child: const Icon(Icons.adb),
             ),
     );
   }

--- a/lib/ui/templates/app_colors_template.dart
+++ b/lib/ui/templates/app_colors_template.dart
@@ -18,6 +18,7 @@ class AppColorsTemplate extends StatelessWidget {
             Container(
               width: MediaQuery.of(context).size.width,
               height: 24,
+              alignment: Alignment.center,
               color: AppColors.primary,
               child: const Text(
                 'primary',
@@ -28,6 +29,7 @@ class AppColorsTemplate extends StatelessWidget {
             Container(
               width: MediaQuery.of(context).size.width,
               height: 24,
+              alignment: Alignment.center,
               color: AppColors.secondary,
               child: const Text(
                 'secondary',
@@ -38,6 +40,7 @@ class AppColorsTemplate extends StatelessWidget {
             Container(
               width: MediaQuery.of(context).size.width,
               height: 24,
+              alignment: Alignment.center,
               color: AppColors.disable,
               child: const Text(
                 'disable',
@@ -48,6 +51,7 @@ class AppColorsTemplate extends StatelessWidget {
             Container(
               width: MediaQuery.of(context).size.width,
               height: 24,
+              alignment: Alignment.center,
               color: AppColors.bgWhite,
               child: const Text(
                 'bgWhite',
@@ -58,6 +62,7 @@ class AppColorsTemplate extends StatelessWidget {
             Container(
               width: MediaQuery.of(context).size.width,
               height: 24,
+              alignment: Alignment.center,
               color: AppColors.stroke,
               child: const Text(
                 'stroke',
@@ -68,6 +73,7 @@ class AppColorsTemplate extends StatelessWidget {
             Container(
               width: MediaQuery.of(context).size.width,
               height: 24,
+              alignment: Alignment.center,
               color: AppColors.textBlack,
               child: const Text(
                 'textBlack',
@@ -79,6 +85,7 @@ class AppColorsTemplate extends StatelessWidget {
             Container(
               width: MediaQuery.of(context).size.width,
               height: 24,
+              alignment: Alignment.center,
               color: AppColors.textGray,
               child: const Text(
                 'textGray',
@@ -90,6 +97,7 @@ class AppColorsTemplate extends StatelessWidget {
             Container(
               width: MediaQuery.of(context).size.width,
               height: 24,
+              alignment: Alignment.center,
               color: AppColors.textBtnWhite,
               child: const Text(
                 'textBtnWhite',
@@ -100,6 +108,7 @@ class AppColorsTemplate extends StatelessWidget {
             Container(
               width: MediaQuery.of(context).size.width,
               height: 24,
+              alignment: Alignment.center,
               color: AppColors.textButton,
               child: const Text(
                 'textButton',

--- a/lib/ui/templates/app_colors_template.dart
+++ b/lib/ui/templates/app_colors_template.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:sweets_app_sample/config/app_routes.dart';
+import 'package:sweets_app_sample/ui/atoms/app_colors.dart';
+
+class AppColorsTemplate extends StatelessWidget {
+  const AppColorsTemplate({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(Pages.appColorsTemplate.name),
+      ),
+      body: SingleChildScrollView(
+        child: Column(
+          children: [
+            const SizedBox(height: 16),
+            Container(
+              width: MediaQuery.of(context).size.width,
+              height: 24,
+              color: AppColors.primary,
+              child: const Text(
+                'primary',
+                textAlign: TextAlign.center,
+              ),
+            ),
+            const SizedBox(height: 16),
+            Container(
+              width: MediaQuery.of(context).size.width,
+              height: 24,
+              color: AppColors.secondary,
+              child: const Text(
+                'secondary',
+                textAlign: TextAlign.center,
+              ),
+            ),
+            const SizedBox(height: 16),
+            Container(
+              width: MediaQuery.of(context).size.width,
+              height: 24,
+              color: AppColors.disable,
+              child: const Text(
+                'disable',
+                textAlign: TextAlign.center,
+              ),
+            ),
+            const SizedBox(height: 16),
+            Container(
+              width: MediaQuery.of(context).size.width,
+              height: 24,
+              color: AppColors.bgWhite,
+              child: const Text(
+                'bgWhite',
+                textAlign: TextAlign.center,
+              ),
+            ),
+            const SizedBox(height: 16),
+            Container(
+              width: MediaQuery.of(context).size.width,
+              height: 24,
+              color: AppColors.stroke,
+              child: const Text(
+                'stroke',
+                textAlign: TextAlign.center,
+              ),
+            ),
+            const SizedBox(height: 16),
+            Container(
+              width: MediaQuery.of(context).size.width,
+              height: 24,
+              color: AppColors.textBlack,
+              child: const Text(
+                'textBlack',
+                textAlign: TextAlign.center,
+                style: TextStyle(color: Colors.white),
+              ),
+            ),
+            const SizedBox(height: 16),
+            Container(
+              width: MediaQuery.of(context).size.width,
+              height: 24,
+              color: AppColors.textGray,
+              child: const Text(
+                'textGray',
+                textAlign: TextAlign.center,
+                style: TextStyle(color: Colors.white),
+              ),
+            ),
+            const SizedBox(height: 16),
+            Container(
+              width: MediaQuery.of(context).size.width,
+              height: 24,
+              color: AppColors.textBtnWhite,
+              child: const Text(
+                'textBtnWhite',
+                textAlign: TextAlign.center,
+              ),
+            ),
+            const SizedBox(height: 16),
+            Container(
+              width: MediaQuery.of(context).size.width,
+              height: 24,
+              color: AppColors.textButton,
+              child: const Text(
+                'textButton',
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/templates/template_top.dart
+++ b/lib/ui/templates/template_top.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:sweets_app_sample/config/app_routes.dart';
+import 'package:sweets_app_sample/viewmodel/template_top_view_model.dart';
+
+class TemplateTop extends StatelessWidget {
+  const TemplateTop({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    // initialize getX Controller
+    final viewModel =
+        Get.put<TemplateTopViewModelInterface>(TemplateTopViewModel.instance);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(Pages.templateTop.name),
+      ),
+      body: SingleChildScrollView(
+        child: Center(
+          child: Column(
+            children: [
+              ElevatedButton(
+                onPressed: () {
+                  viewModel.toTemplateDetail(Pages.appColorsTemplate.routeName);
+                },
+                child: const Text('AppColor'),
+              ),
+              const SizedBox(height: 16)
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/viewmodel/template_top_view_model.dart
+++ b/lib/viewmodel/template_top_view_model.dart
@@ -1,0 +1,14 @@
+import 'package:get/get.dart';
+
+abstract class TemplateTopViewModelInterface extends GetxController {
+  Future<void> toTemplateDetail(String rootName);
+}
+
+class TemplateTopViewModel extends GetxController
+    implements TemplateTopViewModelInterface {
+  static final TemplateTopViewModel instance = TemplateTopViewModel();
+  @override
+  Future<void> toTemplateDetail(String rootName) async {
+    await Get.toNamed<void>(rootName);
+  }
+}

--- a/lib/viewmodel/top_view_mode.dart
+++ b/lib/viewmodel/top_view_mode.dart
@@ -1,0 +1,15 @@
+import 'package:get/get.dart';
+import 'package:sweets_app_sample/config/app_routes.dart';
+
+abstract class TopViewModelInterface extends GetxController {
+  Future<void> toTemplate();
+}
+
+class TopViewModel extends GetxController implements TopViewModelInterface {
+  static final TopViewModel instance = TopViewModel();
+
+  @override
+  Future<void> toTemplate() async {
+    await Get.toNamed<void>(Pages.templateTop.routeName);
+  }
+}


### PR DESCRIPTION
## 対象チケット
https://github.com/mht-ryo-chiba/sweets_app_sample/issues/3

## 実施内容
* アプリ内で使用する色の設定
* 色の種類を確認できるサンプルページの設定
* 暫定でテーマの設定

## レビュー観点
* サンプルページを確認して色設定が理解できるか？


## 動作確認方法
* 実機にて動作確認
  * TopPageのドロイドくんのアイコンをタップ
  * テンプレート一覧でAppColorのボタンをタップ
  * 色の一覧が確認できる



## 範囲(対象の物のみチェックを入れる)
### 種別
- [x] アプリ設定(ライブラリ導入)
- [ ] 画面実装
  - [ ] デザインレビュー
- [ ] 機能実装


## UI仕様書、デザインファイル(URL)
https://www.figma.com/file/RTkbcZQmHGars7DKr3JwBD/Flutter-conference-chiba?node-id=110%3A5120
![スクリーンショット 2021-11-17 14 00 38](https://user-images.githubusercontent.com/20253533/142137757-27a3ecb0-eaf3-409b-a293-5843a3c54096.png)


##  スクリーンショット or　動画
https://user-images.githubusercontent.com/20253533/142139422-a340cf79-b1ce-4549-a080-94a2bb7acafe.mp4


## 関連チケット
なし

## レビュー前に実施すること
- [x] lintのエラーが出ていないこと
- [x] 実機で動作確認を行うこと
- [x] アサイン、レビュワーを設定すること
