### PR TITLE
テキストスタイルとサイズの共通クラスの作成

### DIFF
--- a/lib/config/app_routes.dart
+++ b/lib/config/app_routes.dart
@@ -3,6 +3,7 @@ import 'package:sweets_app_sample/config/app_config.dart';
 import 'package:sweets_app_sample/model/route_data_model.dart';
 import 'package:sweets_app_sample/ui/pages/top.dart';
 import 'package:sweets_app_sample/ui/templates/app_colors_template.dart';
+import 'package:sweets_app_sample/ui/templates/app_text_styles_template.dart';
 import 'package:sweets_app_sample/ui/templates/template_top.dart';
 
 class AppRoutes {
@@ -24,6 +25,12 @@ class AppRoutes {
       routeName: Pages.appColorsTemplate.routeName,
       isDebug: true,
       widgetBuilder: (BuildContext context) => const AppColorsTemplate(),
+    ),
+    RouteDataModel(
+      pageName: Pages.appTextStyleTemplate.name,
+      routeName: Pages.appTextStyleTemplate.routeName,
+      isDebug: true,
+      widgetBuilder: (BuildContext context) => const AppTextStyleTemplate(),
     ),
   ];
 
@@ -51,6 +58,7 @@ enum Pages {
   top,
   templateTop,
   appColorsTemplate,
+  appTextStyleTemplate,
 }
 
 extension PageNameExtension on Pages {
@@ -58,12 +66,14 @@ extension PageNameExtension on Pages {
     Pages.top: 'トップページ',
     Pages.templateTop: 'テンプレートトップ',
     Pages.appColorsTemplate: 'カラーテンプレート',
+    Pages.appTextStyleTemplate: 'テキストスタイルテンプレート',
   };
 
   static final rootNames = {
     Pages.top: '/top',
     Pages.templateTop: '/templateTop',
-    Pages.appColorsTemplate: '/appColorsTemplate'
+    Pages.appColorsTemplate: '/appColorsTemplate',
+    Pages.appTextStyleTemplate: '/appTextStyleTemplate',
   };
 
   String get routeName => rootNames[this] ?? '';

--- a/lib/ui/atoms/app_colors.dart
+++ b/lib/ui/atoms/app_colors.dart
@@ -15,6 +15,6 @@ class AppColors {
   // Text Color
   static const Color textBlack = Color(0xFF333333);
   static const Color textGray = Color(0xFF838383);
-  static const Color textBtnWhite = Color(0xFFFFFFFF);
+  static const Color textButtonWhite = Color(0xFFFFFFFF);
   static const Color textButton = Color(0xFF53D9A9);
 }

--- a/lib/ui/atoms/app_size_list.dart
+++ b/lib/ui/atoms/app_size_list.dart
@@ -1,0 +1,6 @@
+class AppSizelist {
+  // text size
+  static const double largeTextSize = 20;
+  static const double mediumTextSize = 16;
+  static const double smallTextSize = 12;
+}

--- a/lib/ui/atoms/app_text_styles.dart
+++ b/lib/ui/atoms/app_text_styles.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:sweets_app_sample/ui/atoms/app_size_list.dart';
+
+import 'app_colors.dart';
+
+class AppTextStyles {
+  static const TextStyle titleText = TextStyle(
+    fontSize: AppSizelist.largeTextSize,
+    fontWeight: FontWeight.w600,
+    color: AppColors.textBlack,
+  );
+
+  static const TextStyle usernameText = TextStyle(
+    fontSize: AppSizelist.mediumTextSize,
+    fontWeight: FontWeight.w600,
+    color: AppColors.textBlack,
+  );
+
+  static const TextStyle bodyText = TextStyle(
+    fontSize: AppSizelist.mediumTextSize,
+    fontWeight: FontWeight.w300,
+    color: AppColors.textBlack,
+  );
+
+  static const TextStyle subTitleText = TextStyle(
+    fontSize: AppSizelist.smallTextSize,
+    fontWeight: FontWeight.w600,
+    color: AppColors.textGray,
+  );
+
+  static const TextStyle timeText = TextStyle(
+    fontSize: AppSizelist.smallTextSize,
+    fontWeight: FontWeight.w300,
+    color: AppColors.textGray,
+  );
+
+  static const TextStyle textButton = TextStyle(
+    fontSize: AppSizelist.smallTextSize,
+    fontWeight: FontWeight.w600,
+    color: AppColors.textButton,
+  );
+}

--- a/lib/ui/atoms/app_theme.dart
+++ b/lib/ui/atoms/app_theme.dart
@@ -7,6 +7,7 @@ class AppTheme {
       appBarTheme: const AppBarTheme(
         backgroundColor: AppColors.primary,
       ),
+      fontFamily: 'Noto Sans JP',
       brightness: Brightness.light,
     );
   }

--- a/lib/ui/templates/app_colors_template.dart
+++ b/lib/ui/templates/app_colors_template.dart
@@ -98,7 +98,7 @@ class AppColorsTemplate extends StatelessWidget {
               width: MediaQuery.of(context).size.width,
               height: 24,
               alignment: Alignment.center,
-              color: AppColors.textBtnWhite,
+              color: AppColors.textButtonWhite,
               child: const Text(
                 'textBtnWhite',
                 textAlign: TextAlign.center,

--- a/lib/ui/templates/app_text_styles_template.dart
+++ b/lib/ui/templates/app_text_styles_template.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:sweets_app_sample/config/app_routes.dart';
+import 'package:sweets_app_sample/ui/atoms/app_text_styles.dart';
+
+class AppTextStyleTemplate extends StatelessWidget {
+  const AppTextStyleTemplate({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(Pages.appTextStyleTemplate.name),
+      ),
+      body: Center(
+        child: Column(
+          children: const [
+            SizedBox(height: 16),
+            Text(
+              'titleText',
+              style: AppTextStyles.titleText,
+            ),
+            SizedBox(height: 16),
+            Text(
+              'usernameText',
+              style: AppTextStyles.usernameText,
+            ),
+            SizedBox(height: 16),
+            Text(
+              'bodyText',
+              style: AppTextStyles.bodyText,
+            ),
+            SizedBox(height: 16),
+            Text(
+              'subTitleText',
+              style: AppTextStyles.subTitleText,
+            ),
+            SizedBox(height: 16),
+            Text(
+              'timeText',
+              style: AppTextStyles.timeText,
+            ),
+            SizedBox(height: 16),
+            Text(
+              'textButton',
+              style: AppTextStyles.textButton,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/templates/template_top.dart
+++ b/lib/ui/templates/template_top.dart
@@ -24,9 +24,17 @@ class TemplateTop extends StatelessWidget {
                 onPressed: () {
                   viewModel.toTemplateDetail(Pages.appColorsTemplate.routeName);
                 },
-                child: const Text('AppColor'),
+                child: Text(Pages.appColorsTemplate.name),
               ),
-              const SizedBox(height: 16)
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () {
+                  viewModel
+                      .toTemplateDetail(Pages.appTextStyleTemplate.routeName);
+                },
+                child: Text(Pages.appTextStyleTemplate.name),
+              ),
+              const SizedBox(height: 16),
             ],
           ),
         ),


### PR DESCRIPTION
## 対象チケット
https://github.com/mht-ryo-chiba/sweets_app_sample/issues/5

## 実施内容
* アプリ内で使用するテキストスタイルの設定
* サイズに関する共通クラスの作成
* テキストスタイルを確認できるサンプルページの設定
* テーマにフォントファミリーを追加
  * フォントはHiragino Kaku Gothic Proになっているがみきさんに確認し、Noto Sans Japaneseに変更することになった

## レビュー観点
サンプルページを確認してテキストスタイルが理解できるか？


## 動作確認方法
* 実機にて動作確認
  * TopPageのドロイドくんのアイコンをタップ
  * テンプレート一覧でテキストスタイルのボタンをタップ
  * テキストスタイルの一覧が確認できる


## 範囲(対象の物のみチェックを入れる)
### 種別
- [x] アプリ設定(ライブラリ導入)
- [ ] 画面実装
  - [ ] デザインレビュー
- [ ] 機能実装


## UI仕様書、デザインファイル(URL)
https://www.figma.com/file/RTkbcZQmHGars7DKr3JwBD/Flutter-conference-chiba?node-id=110%3A5202
![スクリーンショット 2021-11-17 14 23 07](https://user-images.githubusercontent.com/20253533/142139908-c2b2b397-ee42-413c-b622-39cb354d8e66.png)


##  スクリーンショット or　動画
https://user-images.githubusercontent.com/20253533/142158826-b43778e9-8d62-4189-9796-36cc172aeaeb.mp4


## 関連チケット
なし

## レビュー前に実施すること
- [x] lintのエラーが出ていないこと
- [x] 実機で動作確認を行うこと
- [x] アサイン、レビュワーを設定すること
