### PR TITLE
shopDetailWidgetの作成

### DIFF
--- a/lib/config/constants.dart
+++ b/lib/config/constants.dart
@@ -1,0 +1,3 @@
+class Constants {
+  static const String sampleJsonPath = 'assets/sample_json/';
+}

--- a/lib/model/shop_list_model.dart
+++ b/lib/model/shop_list_model.dart
@@ -1,0 +1,16 @@
+import 'package:sweets_app_sample/model/shop_model.dart';
+
+class ShopListModel {
+  const ShopListModel({required this.shopList});
+
+  factory ShopListModel.fromJson(Map<String, dynamic> json) {
+    final shopDataList = <ShopModel>[];
+    if (json['shop_list'] != null) {
+      for (final shopData in json['shop_list']) {
+        shopDataList.add(ShopModel.fromJson(shopData as Map<String, dynamic>));
+      }
+    }
+    return ShopListModel(shopList: shopDataList);
+  }
+  final List<ShopModel> shopList;
+}

--- a/lib/model/shop_model.dart
+++ b/lib/model/shop_model.dart
@@ -1,0 +1,19 @@
+class ShopModel {
+  const ShopModel({
+    required this.shopName,
+    required this.shopAddress,
+    required this.imageSrc,
+  });
+
+  factory ShopModel.fromJson(Map<String, dynamic> json) {
+    return ShopModel(
+      shopName: json['shop_name'] as String,
+      shopAddress: json['shop_address'] as String,
+      imageSrc: json['image_src'] as String,
+    );
+  }
+
+  final String shopName;
+  final String shopAddress;
+  final String imageSrc;
+}

--- a/lib/repository/api.dart
+++ b/lib/repository/api.dart
@@ -1,0 +1,22 @@
+import 'package:dio/dio.dart';
+import 'package:sweets_app_sample/config/app_config.dart';
+
+class Api {
+  Api() {
+    // タイムアウト設定
+    dio.options.connectTimeout = 5000;
+    // ログ設定
+    if (!AppConfig().isRelease()) {
+      dio.interceptors.add(LogInterceptor(
+        responseBody: true,
+        request: true,
+      ));
+    }
+  }
+
+  // API通信を行う実態
+  final Dio dio = Dio();
+
+  // stabを使うかの判定
+  bool isStab = false;
+}

--- a/lib/repository/shop_list_repository.dart
+++ b/lib/repository/shop_list_repository.dart
@@ -1,0 +1,35 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:sweets_app_sample/config/constants.dart';
+import 'package:sweets_app_sample/model/shop_list_model.dart';
+import 'package:sweets_app_sample/repository/api.dart';
+
+class ShopListRepository extends Api {
+  ShopListRepository() {
+    // スタブを使用するかの個別判定
+    isStab = true;
+
+    // エンドポイント(環境により切り替える)
+    dio.options.baseUrl = 'https://test-url.com';
+  }
+  Future<ShopListModel?> getShopList() async {
+    if (isStab) {
+      // スタブ環境用のロジックを記載する
+      final loadData = await rootBundle
+          .loadString('${Constants.sampleJsonPath}shop_list.json');
+      return ShopListModel.fromJson(
+          json.decode(loadData) as Map<String, dynamic>);
+    } else {
+      // 本番用(暫定)
+      return dio.get<String>('/shopList').then((response) {
+        if (response.statusCode == 200) {
+          return ShopListModel.fromJson(
+              json.decode(response.data ?? '') as Map<String, dynamic>);
+        } else {
+          return null;
+        }
+      });
+    }
+  }
+}

--- a/lib/ui/atoms/app_size_list.dart
+++ b/lib/ui/atoms/app_size_list.dart
@@ -13,5 +13,5 @@ class AppSizeList {
   // size
   static const double largeSize = 24;
   static const double mediumSize = 16;
-  static const double smallSize = 4;
+  static const double smallSize = 8;
 }

--- a/lib/ui/molecules/circle_icon_image.dart
+++ b/lib/ui/molecules/circle_icon_image.dart
@@ -10,7 +10,11 @@ class CircleIconImage extends StatelessWidget {
     return Container(
       width: AppSizeList.smallImageSize,
       height: AppSizeList.smallImageSize,
-      margin: const EdgeInsets.all(AppSizeList.mediumSize),
+      margin: const EdgeInsets.only(
+          top: AppSizeList.mediumSize,
+          right: AppSizeList.smallSize,
+          bottom: AppSizeList.mediumSize,
+          left: AppSizeList.mediumSize),
       child: ClipOval(
         child: image,
       ),

--- a/lib/ui/organisms/comment_detail_widget.dart
+++ b/lib/ui/organisms/comment_detail_widget.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:sweets_app_sample/ui/atoms/app_size_list.dart';
+import 'package:sweets_app_sample/ui/atoms/app_text_styles.dart';
+import 'package:sweets_app_sample/ui/molecules/circle_icon_image.dart';
+
+class CommentDetailWidget extends StatelessWidget {
+  const CommentDetailWidget({
+    Key? key,
+    required this.userName,
+    required this.createString,
+    required this.comment,
+    required this.src,
+    required this.tapFunction,
+  }) : super(key: key);
+
+  final String userName;
+  final String createString;
+  final String comment;
+  final String src;
+  final VoidCallback tapFunction;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        CircleIconImage(
+          image: Image.network(
+            src,
+            fit: BoxFit.cover,
+          ),
+        ),
+        Flexible(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Padding(
+                padding: const EdgeInsets.only(
+                  top: AppSizeList.mediumSize,
+                  right: AppSizeList.mediumSize,
+                ),
+                child: Text(
+                  userName,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: AppTextStyles.titleText,
+                ),
+              ),
+              Text(
+                createString,
+                style: AppTextStyles.timeText,
+              ),
+              Padding(
+                padding: const EdgeInsets.only(
+                  top: AppSizeList.smallSize,
+                  right: AppSizeList.mediumSize,
+                ),
+                child: Text(
+                  comment,
+                  style: AppTextStyles.bodyText,
+                ),
+              ),
+              InkWell(
+                onTap: tapFunction,
+                child: const Padding(
+                  padding: EdgeInsets.only(
+                    top: AppSizeList.smallSize,
+                  ),
+                  child: Text(
+                    'Reply',
+                    style: AppTextStyles.textButton,
+                  ),
+                ),
+              )
+            ],
+          ),
+        )
+      ],
+    );
+  }
+}

--- a/lib/ui/organisms/shop_detail_widget.dart
+++ b/lib/ui/organisms/shop_detail_widget.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+import 'package:sweets_app_sample/ui/atoms/app_size_list.dart';
+import 'package:sweets_app_sample/ui/atoms/app_text_styles.dart';
+import 'package:sweets_app_sample/ui/molecules/angle_circle_large_image.dart';
+
+class ShopDetailWidget extends StatelessWidget {
+  const ShopDetailWidget({
+    Key? key,
+    required this.shopName,
+    required this.shopOpenTime,
+    required this.shopPhoneNo,
+    required this.shopAddress,
+    required this.src,
+  }) : super(key: key);
+
+  final String shopName;
+  final String shopOpenTime;
+  final String shopPhoneNo;
+  final String shopAddress;
+  final String src;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        AngleCircleLargeImage(
+          image: Image.network(
+            src,
+            fit: BoxFit.cover,
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSizeList.mediumSize,
+          ),
+          child: Text(
+            shopName,
+            style: AppTextStyles.titleText,
+          ),
+        ),
+        const Padding(
+          padding: EdgeInsets.only(
+            top: AppSizeList.smallSize,
+            right: AppSizeList.mediumSize,
+            left: AppSizeList.mediumSize,
+          ),
+          child: Text(
+            'OPEN',
+            style: AppTextStyles.subTitleText,
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSizeList.mediumSize,
+          ),
+          child: Text(
+            shopOpenTime,
+            style: AppTextStyles.bodyText,
+          ),
+        ),
+        const Padding(
+          padding: EdgeInsets.only(
+            top: AppSizeList.smallSize,
+            right: AppSizeList.mediumSize,
+            left: AppSizeList.mediumSize,
+          ),
+          child: Text(
+            'PHONE',
+            style: AppTextStyles.subTitleText,
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: AppSizeList.mediumSize,
+          ),
+          child: Text(
+            shopPhoneNo,
+            style: AppTextStyles.bodyText,
+          ),
+        ),
+        const Padding(
+          padding: EdgeInsets.only(
+            top: AppSizeList.smallSize,
+            right: AppSizeList.mediumSize,
+            left: AppSizeList.mediumSize,
+          ),
+          child: Text(
+            'ADDRESS',
+            style: AppTextStyles.subTitleText,
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.only(
+            right: AppSizeList.mediumSize,
+            left: AppSizeList.mediumSize,
+            bottom: AppSizeList.mediumSize,
+          ),
+          child: Text(
+            shopAddress,
+            style: AppTextStyles.bodyText,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/ui/organisms/shop_list_widget.dart
+++ b/lib/ui/organisms/shop_list_widget.dart
@@ -19,47 +19,44 @@ class ShopListWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Card(
-      margin: const EdgeInsets.all(AppSizeList.mediumSize),
-      child: InkWell(
-        onTap: tapFunction,
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            AngleCircleIconImage(
-              image: Image.network(
-                src,
-                fit: BoxFit.cover,
-              ),
+    return InkWell(
+      onTap: tapFunction,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          AngleCircleIconImage(
+            image: Image.network(
+              src,
+              fit: BoxFit.cover,
             ),
-            Flexible(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.only(top: AppSizeList.mediumSize),
-                    child: Text(
-                      shopName,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: AppTextStyles.titleText,
-                    ),
+          ),
+          Flexible(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.only(top: AppSizeList.mediumSize),
+                  child: Text(
+                    shopName,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: AppTextStyles.titleText,
                   ),
-                  Padding(
-                    padding: const EdgeInsets.only(top: AppSizeList.smallSize),
-                    child: Text(
-                      shopAddress,
-                      maxLines: 1,
-                      overflow: TextOverflow.ellipsis,
-                      style: AppTextStyles.bodyText,
-                    ),
-                  )
-                ],
-              ),
-            )
-          ],
-        ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(top: AppSizeList.smallSize),
+                  child: Text(
+                    shopAddress,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: AppTextStyles.bodyText,
+                  ),
+                )
+              ],
+            ),
+          )
+        ],
       ),
     );
   }

--- a/lib/ui/pages/top.dart
+++ b/lib/ui/pages/top.dart
@@ -21,26 +21,27 @@ class Top extends StatelessWidget {
       body: GetBuilder<TopViewModel>(
           init: viewModel,
           builder: (_) {
-            return ListView.separated(
-              itemCount: viewModel.shopDataList.shopList.length,
-              separatorBuilder: (context, index) {
-                return const Divider(height: 1);
-              },
-              itemBuilder: (BuildContext context, int index) {
-                return ShopListWidget(
-                  shopName:
-                      viewModel.shopDataList
-                        .shopList[index].shopName,
-                  shopAddress:
-                      viewModel.shopDataList
-                          .shopList[index].shopAddress,
-                  src:
-                      viewModel.shopDataList
-                          .shopList[index].imageSrc,
-                  tapFunction: () {},
-                );
-              },
-            );
+            if (viewModel.shopDataList.shopList.length.isGreaterThan(0)) {
+              return ListView.separated(
+                itemCount: viewModel.shopDataList.shopList.length,
+                separatorBuilder: (context, index) {
+                  return const Divider(height: 1);
+                },
+                itemBuilder: (BuildContext context, int index) {
+                  return ShopListWidget(
+                    shopName: viewModel.shopDataList.shopList[index].shopName,
+                    shopAddress:
+                        viewModel.shopDataList.shopList[index].shopAddress,
+                    src: viewModel.shopDataList.shopList[index].imageSrc,
+                    tapFunction: () {},
+                  );
+                },
+              );
+            } else {
+              return const Center(
+                child: CircularProgressIndicator(),
+              );
+            }
           }),
       // デバッグ時のみフローティングボタンを表示
       floatingActionButton: AppConfig().isRelease()

--- a/lib/ui/pages/top.dart
+++ b/lib/ui/pages/top.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:sweets_app_sample/config/app_config.dart';
 import 'package:sweets_app_sample/ui/atoms/app_colors.dart';
+import 'package:sweets_app_sample/ui/organisms/shop_list_widget.dart';
 import 'package:sweets_app_sample/viewmodel/top_view_mode.dart';
 
 class Top extends StatelessWidget {
@@ -10,15 +11,37 @@ class Top extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // initialize getX Controller
-    final viewModel = Get.put<TopViewModelInterface>(TopViewModel.instance);
+    final viewModel = Get.put<TopViewModel>(TopViewModel.instance);
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('sweets_app'),
+        centerTitle: true,
+        title: const Text('sweets倶楽部'),
       ),
-      body: const Center(
-        child: Text('TOP Page'),
-      ),
+      body: GetBuilder<TopViewModel>(
+          init: viewModel,
+          builder: (_) {
+            return ListView.separated(
+              itemCount: viewModel.shopDataList.shopList.length,
+              separatorBuilder: (context, index) {
+                return const Divider(height: 1);
+              },
+              itemBuilder: (BuildContext context, int index) {
+                return ShopListWidget(
+                  shopName:
+                      viewModel.shopDataList
+                        .shopList[index].shopName,
+                  shopAddress:
+                      viewModel.shopDataList
+                          .shopList[index].shopAddress,
+                  src:
+                      viewModel.shopDataList
+                          .shopList[index].imageSrc,
+                  tapFunction: () {},
+                );
+              },
+            );
+          }),
       // デバッグ時のみフローティングボタンを表示
       floatingActionButton: AppConfig().isRelease()
           ? null

--- a/lib/ui/templates/app_parts_list_template.dart
+++ b/lib/ui/templates/app_parts_list_template.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:sweets_app_sample/config/app_routes.dart';
 import 'package:sweets_app_sample/ui/atoms/app_text_styles.dart';
 import 'package:sweets_app_sample/ui/organisms/comment_detail_widget.dart';
+import 'package:sweets_app_sample/ui/organisms/shop_detail_widget.dart';
 import 'package:sweets_app_sample/ui/organisms/shop_list_widget.dart';
 
 class AppPartsListTemplate extends StatelessWidget {
@@ -32,6 +33,26 @@ class AppPartsListTemplate extends StatelessWidget {
               shopName: '長めの店舗名です長めの店舗名です長めの店舗名です長めの店舗名です長めの店舗名です',
               shopAddress: '長めの住所です長めの住所です長めの住所です長めの住所です長めの住所です',
               tapFunction: () {},
+            ),
+            const Divider(color: Colors.black),
+            const SizedBox(height: 16),
+            const Text(
+              'CommentDetailWidget',
+              style: AppTextStyles.titleText,
+            ),
+            const ShopDetailWidget(
+              shopName: '店舗名テキスト',
+              shopOpenTime: '10:00 - 19:00',
+              shopPhoneNo: '01-2345-6789',
+              shopAddress: '東京都千代田区1-1-1',
+              src: 'https://placehold.jp/500x500.png',
+            ),
+            const ShopDetailWidget(
+              shopName: '長めの店舗名テキスト長めの店舗名テキスト長めの店舗名テキスト',
+              shopOpenTime: '不定期',
+              shopPhoneNo: '-',
+              shopAddress: '-',
+              src: 'https://placehold.jp/500x500.png',
             ),
             const Divider(color: Colors.black),
             const SizedBox(height: 16),

--- a/lib/ui/templates/app_parts_list_template.dart
+++ b/lib/ui/templates/app_parts_list_template.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:sweets_app_sample/config/app_routes.dart';
 import 'package:sweets_app_sample/ui/atoms/app_text_styles.dart';
+import 'package:sweets_app_sample/ui/organisms/comment_detail_widget.dart';
 import 'package:sweets_app_sample/ui/organisms/shop_list_widget.dart';
 
 class AppPartsListTemplate extends StatelessWidget {
@@ -33,6 +34,26 @@ class AppPartsListTemplate extends StatelessWidget {
               tapFunction: () {},
             ),
             const Divider(color: Colors.black),
+            const SizedBox(height: 16),
+            const Text(
+              'CommentDetailWidget',
+              style: AppTextStyles.titleText,
+            ),
+            CommentDetailWidget(
+              userName: '山田太郎',
+              createString: '1時間前',
+              comment: 'ここにはユーザーのコメントが入ります',
+              src: 'https://placehold.jp/500x500.png',
+              tapFunction: () {},
+            ),
+            CommentDetailWidget(
+              userName: '長い名前です長い名前です長い名前です長い名前です長い名前です',
+              createString: '1時間前',
+              comment:
+                  'コメントを全文表示、長い場合は複数行にする\nサンプルテキストサンプルテキストサンプルテキストサンプルテキスト',
+              src: 'https://placehold.jp/500x500.png',
+              tapFunction: () {},
+            )
           ],
         ),
       ),

--- a/lib/viewmodel/top_view_mode.dart
+++ b/lib/viewmodel/top_view_mode.dart
@@ -1,12 +1,37 @@
 import 'package:get/get.dart';
 import 'package:sweets_app_sample/config/app_routes.dart';
+import 'package:sweets_app_sample/model/shop_list_model.dart';
+import 'package:sweets_app_sample/repository/shop_list_repository.dart';
 
 abstract class TopViewModelInterface extends GetxController {
   Future<void> toTemplate();
+  ShopListModel get shopDataList;
 }
 
 class TopViewModel extends GetxController implements TopViewModelInterface {
-  static final TopViewModel instance = TopViewModel();
+  TopViewModel._() {
+    () async {
+      // 擬似的にAPI通信を行う
+      await callApi();
+    }();
+  }
+
+  static final TopViewModel instance = TopViewModel._();
+
+  late ShopListModel _shopDataList =
+      ShopListModel.fromJson(<String, dynamic>{});
+
+  Future<void> callApi() async {
+    await ShopListRepository().getShopList().then((response) {
+      if (response != null) {
+        _shopDataList = response;
+        update();
+      }
+    });
+  }
+
+  @override
+  ShopListModel get shopDataList => _shopDataList;
 
   @override
   Future<void> toTemplate() async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,6 +57,7 @@ flutter:
   # To add assets to your application, add an assets section, like this:
   assets:
     - assets/images/
+    - assets/sample_json/
   #   - images/a_dot_ham.jpeg
 
   # An image asset can refer to one or more resolution-specific "variants", see


### PR DESCRIPTION
## 対象チケット
https://github.com/mht-ryo-chiba/sweets_app_sample/issues/15

## 実施内容
* shopDetailWidgetの作成
* テンプレートページでshopDetailWidgetを確認できるようにする

## レビュー観点
パーツリストのページを見てshopDetailWidgetの使い方を理解できること


## 動作確認方法
* 実機にて動作確認
  * TopPageのドロイドくんのアイコンをタップ
  * テンプレート一覧でパーツテンプレートのボタンをタップ
  * パーツテンプレートのshopDetailWidgetが確認できる



## 範囲(対象の物のみチェックを入れる)
### 種別
- [x] アプリ設定(ライブラリ導入)
- [ ] 画面実装
  - [ ] デザインレビュー
- [ ] 機能実装


## UI仕様書、デザインファイル(URL)
https://www.figma.com/file/RTkbcZQmHGars7DKr3JwBD/Flutter-conference-chiba?node-id=110%3A5454
![スクリーンショット 2021-11-19 4 20 31](https://user-images.githubusercontent.com/20253533/142482648-e98975ac-9a0d-4429-ad11-22635d282570.png)


##  スクリーンショット or　動画
https://user-images.githubusercontent.com/20253533/142488459-ad44f71e-09c1-4bd7-99f0-46bdfd8f27cd.mp4


## 関連チケット
**上から順にマージしていくこと**
https://github.com/mht-ryo-chiba/sweets_app_sample/pull/12
https://github.com/mht-ryo-chiba/sweets_app_sample/pull/14

## レビュー前に実施すること
- [x] lintのエラーが出ていないこと
- [x] 実機で動作確認を行うこと
- [x] アサイン、レビュワーを設定すること
